### PR TITLE
addField -> (s) && add EmbedBuilder

### DIFF
--- a/actions/add_embed_field.js
+++ b/actions/add_embed_field.js
@@ -112,13 +112,15 @@ module.exports = {
 		const data = cache.actions[cache.index];
 		const storage = parseInt(data.storage, 10);
 		const varName = this.evalMessage(data.varName, cache);
-		const embed = this.getVariable(storage, varName, cache);
+		let embed = this.getVariable(storage, varName, cache);
 		const name = this.evalMessage(data.fieldName, cache);
 		const message = this.evalMessage(data.message, cache);
 		const inline = data.inline === "0";
-		if (embed?.addField) {
-			embed.addField(name, message, inline);
-		}
+		
+		const { EmbedBuilder } = this.getDBM().DiscordJS;
+		embed = EmbedBuilder.from(embed).addFields({ name, value: message, inline });
+
+		this.storeValue(embed, storage, varName, cache);
 		this.callNextAction(cache);
 	},
 

--- a/actions/send_message.js
+++ b/actions/send_message.js
@@ -629,11 +629,13 @@ module.exports = {
 					const fields = embedData.fields;
 					for (let i = 0; i < fields.length; i++) {
 						const f = fields[i];
-						embed.addField(
-							this.evalMessage(f.name, cache),
-							this.evalMessage(f.value, cache),
-							f.inline === "true",
-						);
+						embed.addFields([
+							{
+								name: this.evalMessage(f.name, cache),
+								value: this.evalMessage(f.value, cache),
+								inline: f.inline === "true",
+							},
+						]);
 					}
 				}
 

--- a/actions/set_embed_description.js
+++ b/actions/set_embed_description.js
@@ -90,8 +90,12 @@ module.exports = {
 		const data = cache.actions[cache.index];
 		const storage = parseInt(data.storage, 10);
 		const varName = this.evalMessage(data.varName, cache);
-		const embed = this.getVariable(storage, varName, cache);
-		embed?.setDescription?.(this.evalMessage(data.message, cache));
+		let embed = this.getVariable(storage, varName, cache);
+		
+		const { EmbedBuilder } = this.getDBM().DiscordJS;
+		embed = EmbedBuilder.from(embed).setDescription(this.evalMessage(data.message, cache));
+
+		this.storeValue(embed, storage, varName, cache);
 		this.callNextAction(cache);
 	},
 

--- a/actions/set_embed_footer.js
+++ b/actions/set_embed_footer.js
@@ -96,11 +96,15 @@ module.exports = {
 		const data = cache.actions[cache.index];
 		const storage = parseInt(data.storage, 10);
 		const varName = this.evalMessage(data.varName, cache);
-		const embed = this.getVariable(storage, varName, cache);
-		embed?.setFooter?.({
+		let embed = this.getVariable(storage, varName, cache);
+		
+		const { EmbedBuilder } = this.getDBM().DiscordJS;
+		embed = EmbedBuilder.from(embed).setFooter({
 			text: this.evalMessage(data.message, cache),
 			iconURL: this.evalMessage(data.footerIcon, cache),
 		});
+
+		this.storeValue(embed, storage, varName, cache);
 		this.callNextAction(cache);
 	},
 


### PR DESCRIPTION
This should allow closing #32.

Replaced addField with addFields, and added EmbedBuilder.from(embed) in embed editing actions because Builders are no longer returned by the API like they were previously.

I have tested all of these and they work in DBM 2.1.7. As it is breaking changes from discord / discord.js, I don't think backwards compatibility is required to be looked at.