### PR TITLE
Add a check if list is undefined in convert_list_to_text

### DIFF
--- a/actions/convert_list_to_text.js
+++ b/actions/convert_list_to_text.js
@@ -139,6 +139,11 @@ module.exports = {
 		const end = this.evalMessage(data.end, cache).replace("\\n", "\n");
 		let result = "";
 
+		if (!list) {
+			this.callNextAction(cache);
+			return;
+		}
+
 		for (let i = 0; i < list.length; i++) {
 			if (i === 0) {
 				result += start + String(list[i]) + end;


### PR DESCRIPTION
Instead of being forced to check if list is undefined beforehand, call next action.

fixes: `TypeError: Cannot read properties of undefined (reading 'length')`